### PR TITLE
Better search navigation

### DIFF
--- a/public/styles/posts.css
+++ b/public/styles/posts.css
@@ -41,3 +41,10 @@ div.page-links {
 .edition-line {
     text-align: center;
 }
+
+.search-first-last-links {
+    margin-top: 0.5rem;
+    justify-content: center;
+    display: flex;
+    gap: 0.5rem;
+}

--- a/src/routes/search.ts
+++ b/src/routes/search.ts
@@ -38,6 +38,12 @@ export const index = (req: Request, res: Response) => {
             prevPage: updateQuery({
                 page: String(clamp(page - 1, 1, results.totalPages)),
             }),
+            firstPage: updateQuery({
+                page: "1",
+            }),
+            lastPage: updateQuery({
+                page: results.totalPages.toString(),
+            }),
         },
         currentEdition: edition.noEdition ? undefined : edition.number,
         editions,

--- a/templates/posts.liquid
+++ b/templates/posts.liquid
@@ -51,6 +51,23 @@
     </div>
 </form>
 
+{% if hasQuery %}
+    <div class="nag filter-nag">Some posts have been filtered. 
+        <a href="/posts">Reset</a>
+    </div>
+{% endif %}
+
+
+<div class="search-first-last-links">
+    {% if page != 1 %}
+        <a href="{{ links.firstPage }}">First</a>
+    {% endif %}
+    Page {{ page }} of {{ results.totalPages }}
+    {% if page != results.totalPages %}
+        <a href="{{ links.lastPage }}">Last</a>
+    {% endif %}
+</div>
+
 {% if results.posts.size %}
 <div class="posts">
     {% for post in results.posts %}

--- a/templates/posts.liquid
+++ b/templates/posts.liquid
@@ -51,6 +51,8 @@
     </div>
 </form>
 
+{% if results.posts.size %}
+
 {% if hasQuery %}
     <div class="nag filter-nag">Some posts have been filtered. 
         <a href="/posts">Reset</a>
@@ -68,7 +70,6 @@
     {% endif %}
 </div>
 
-{% if results.posts.size %}
 <div class="posts">
     {% for post in results.posts %}
         {% render 'partials/post.liquid' post: post %}


### PR DESCRIPTION
Fixes #9. Added a link to clear filters and links for jumping to first/last page to the search view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct First and Last page links to search results for quicker navigation.
  * Display current page and total pages within the search pagination.
  * Show a banner when results are filtered, with a Reset link to view all posts.
* **Style**
  * Introduced a new CSS class to layout the first/last pagination links with centered alignment and spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->